### PR TITLE
Add TensorBoard logging to linear equation training

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ml-math-equations
-A project to demonstrate the "universalness" of neural networks. I want to train simple neural networks to learn some simple math equations
+A project to demonstrate the "universalness" of neural networks. I want to train simple neural networks to learn some simple math equations.
+
+The training script in `linear.py` now uses **TensorBoard** to visualize how the model output compares to the target linear equation. Every 100 epochs a plot of the true line versus the network prediction in the range ``-30`` to ``30`` is logged. Training runs for 1000 epochs by default so you can track the improvement over time.

--- a/linear.py
+++ b/linear.py
@@ -2,6 +2,8 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import numpy as np
+import matplotlib.pyplot as plt
+from torch.utils.tensorboard import SummaryWriter
 
 
 class LinearEquationDataset(torch.utils.data.Dataset):
@@ -33,13 +35,20 @@ class LinearEquationNN(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
 
-def train_linear_model(model: nn.Module, dataset: torch.utils.data.Dataset,
-                       num_epochs: int = 1000, learning_rate: float = 0.01) -> None:
-    """Train ``model`` on ``dataset`` using mean squared error."""
+def train_linear_model(
+    model: nn.Module,
+    dataset: torch.utils.data.Dataset,
+    num_epochs: int = 1000,
+    learning_rate: float = 0.01,
+    log_interval: int = 100,
+    log_dir: str = "runs/linear",
+) -> None:
+    """Train ``model`` on ``dataset`` using mean squared error and log results to TensorBoard."""
 
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)
     criterion = nn.MSELoss()
     optimizer = optim.SGD(model.parameters(), lr=learning_rate)
+    writer = SummaryWriter(log_dir=log_dir)
 
     for epoch in range(num_epochs):
         for x, y in dataloader:
@@ -50,9 +59,23 @@ def train_linear_model(model: nn.Module, dataset: torch.utils.data.Dataset,
             loss.backward()
             optimizer.step()
 
-        if (epoch + 1) % 100 == 0:
+        if (epoch + 1) % log_interval == 0:
             print(f"Epoch [{epoch + 1}/{num_epochs}]\tLoss: {loss.item():.6f}")
 
+            # Generate a figure comparing the learned model to the target equation
+            with torch.no_grad():
+                xs = torch.linspace(-30, 30, steps=61).view(-1, 1)
+                ys_true = 2 * xs + 3
+                ys_pred = model(xs)
+
+            fig = plt.figure()
+            plt.plot(xs.numpy(), ys_true.numpy(), label="target")
+            plt.plot(xs.numpy(), ys_pred.numpy(), label="model")
+            plt.legend()
+            writer.add_figure("target_vs_model", fig, global_step=epoch + 1)
+            plt.close(fig)
+
+    writer.close()
     print("Training complete.\n")
 
 def evaluate_linear_model(model: nn.Module, dataset: torch.utils.data.Dataset) -> np.ndarray:
@@ -83,7 +106,7 @@ def main() -> None:
     dataset = LinearEquationDataset(num_samples=1000)
     model = LinearEquationNN()
 
-    train_linear_model(model, dataset, num_epochs=200, learning_rate=0.01)
+    train_linear_model(model, dataset, num_epochs=1000, learning_rate=0.01)
 
     preds = evaluate_linear_model(model, dataset)
     weight = model.linear.weight.item()


### PR DESCRIPTION
## Summary
- log model vs. target equation to TensorBoard during training
- extend training loop to 1000 epochs
- document TensorBoard usage in README

## Testing
- `python -m py_compile linear.py`
- `python linear.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683e72107f1c832b8fcda15d23c80f07